### PR TITLE
Fix Pluto flat mode bugs

### DIFF
--- a/llvm/lib/Transforms/Obfuscation/Flattening.cpp
+++ b/llvm/lib/Transforms/Obfuscation/Flattening.cpp
@@ -50,6 +50,12 @@ void Flattening::flatten(Function &F) {
 
     for (BasicBlock &BB : F) {
         origBB.push_back(&BB);
+
+        unsigned int op = BB.getTerminator()->getOpcode();
+        if(op != Instruction::Br && op != Instruction::Ret){
+            use_flat = 0;
+            break;
+        }
     }
 
     if(has_unsupported_ir(F)){


### PR DESCRIPTION
1. Fix bug: compilation error when processing IRs that contain error handling instructions.
2. Fix bug: compilation error when PHI instruction exists.

for example:
```
int func(int a, int b){
    return a + b;
}

int main(){
    int a, b, c;
    scanf("%d %d %d");
    printf("%d", func(c ? a : b, c ? a : b )); // compilation error (which generates phi instruction)
}
```